### PR TITLE
Fix overflowing layout on info.html

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,7 +1,3 @@
-* {
-  box-sizing: border-box;
-}
-
 html, body {
   height: 100%;
   margin: 0;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 html, body {
   height: 100%;
   margin: 0;

--- a/static/info.html
+++ b/static/info.html
@@ -7,6 +7,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
+        * {
+            box-sizing: border-box;
+        }
+        
 		html, body {
 			height: 100%;
 			margin: 0;


### PR DESCRIPTION
### Why

Elements of `info.html` take up more than 100% of the viewport width, this adds a useless scrollbar on desktop and cuts off content on mobile

### How

- adds [a common reset](https://css-tricks.com/box-sizing/) for box-sizing